### PR TITLE
Add test to check if imported scripts are/aren't executed

### DIFF
--- a/tests/html/cloned-template-script.html
+++ b/tests/html/cloned-template-script.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>cloned template script Test</title>
+    <script src="../../html-imports.min.js"></script>
+    <script>WCT = {waitFor: function(cb){cb()}};</script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <link rel="import" href="imports/template-import.html" id="template-script">
+  </head>
+  <body>
+    <script>
+      test('cloned template script execution', function(done) {
+        // In native HTMLImports the event 'HTMLImportsLoaded' might have already
+        // been fired by this time, so use HTMLImports.whenReady.
+        HTMLImports.whenReady(function() {
+          chai.assert.isUndefined(window.executedTemplateScript, 'remote template script is NOT executed after import');
+          const template = document.querySelector('#template-script').import.querySelector('template');
+          document.head.appendChild(document.importNode(template.content, true));
+          chai.assert.isTrue(window.executedTemplateScript, 'remote template script executed after clone and attach to the main document');
+          done();
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -48,5 +48,6 @@
     'html/import-for-element.html',
     'html/ready-state.html',
     'html/resolve-path.html',
+    'html/cloned-template-script.html'
   ]);
 </script>


### PR DESCRIPTION
It seems there was a file for it already, but it was not used https://github.com/webcomponents/html-imports/blob/master/tests/html/imports/template-import.html

Tests script execution as speced, implemented in Chrome and V0 polyfill:
- `<script>` inside `<template>` inside imported document should not be executed,
- `<script>` cloned from imported `<template>`.content to the main document should be executed.

This actually fails as it should, due to
https://github.com/webcomponents/webcomponentsjs/issues/872