### PR TITLE
Replace `_currentScript` with `currentScript`in tests descriptions

### DIFF
--- a/tests/html/currentScript.html
+++ b/tests/html/currentScript.html
@@ -10,7 +10,7 @@
 -->
 <html>
   <head>
-    <title>_currentScript Test</title>
+    <title>currentScript Test</title>
     <script src="../../html-imports.min.js"></script>
     <script>WCT = {waitFor: function(cb){cb()}};</script>
     <script src="../../../web-component-tester/browser.js"></script>
@@ -21,7 +21,7 @@
     <script>
       var cs = document.currentScript;
       test('currentScript', function(done) {
-        chai.assert.equal(cs.parentNode, document.body, '_currentScript set in main document');
+        chai.assert.equal(cs.parentNode, document.body, 'currentScript set in main document');
         // In native HTMLImports the event 'HTMLImportsLoaded' might have already
         // been fired by this time, so use HTMLImports.whenReady.
         HTMLImports.whenReady(function() {

--- a/tests/html/imports/script-1.html
+++ b/tests/html/imports/script-1.html
@@ -11,6 +11,6 @@
 <script>
   chai.assert.ok(document.currentScript);
   var d = document.currentScript.ownerDocument.querySelector('div');
-  chai.assert.equal(d.innerHTML, 'me', '_currentScript can locate element in import')
+  chai.assert.equal(d.innerHTML, 'me', 'currentScript can locate element in import')
 </script>
 <script src="current-script.js"></script>

--- a/tests/html/imports/script-2.html
+++ b/tests/html/imports/script-2.html
@@ -10,6 +10,6 @@
 <div>me2</div>
 <script>
   var d = document.currentScript.ownerDocument.querySelector('div');
-  chai.assert.equal(d.innerText, 'me2', '_currentScript can locate element in import')
+  chai.assert.equal(d.innerText, 'me2', 'currentScript can locate element in import')
 </script>
 <link rel="import" href="imports/script-2.html">


### PR DESCRIPTION
It seems like a legacy after old implementation where `_currentScript` was in use.