### PR TITLE
Added bower 'web-component-tester' install to install script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "gulp",
+    "install": "bower install --save-dev web-component-tester",
     "test": "wct"
   },
   "homepage": "https://webcomponents.org/polyfills",


### PR DESCRIPTION
Added 'npm install' script with 'bower install --save-dev web-component-tester' bower install. This avoids the wct error stating the bower install line.